### PR TITLE
Allow for non-full page uses

### DIFF
--- a/src/Slideshow.css
+++ b/src/Slideshow.css
@@ -1,10 +1,3 @@
-html,
-body {
-  padding: 0;
-  margin: 0;
-  background: #000;
-}
-
 .slideshow-container {
   position: absolute;
   height: 100%;
@@ -186,7 +179,7 @@ body {
   opacity: 1;
 }
 
-button:focus {
+.slideshow-container button:focus {
   outline: none;
 }
 


### PR DESCRIPTION
The styles applied to this component affect parent components as well.

This is fine when the slideshow is the only element on the page, but when it needs to be present along side other elements, it can inadvertently change styles in a problematic way.

This PR aims to fix that.

- [x] remove competing styles
~- [ ] add background back in to demo~